### PR TITLE
END-144 Now using opensaml-ext 0.9.2

### DIFF
--- a/attribute-support/pom.xml
+++ b/attribute-support/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <relativePath>../parent-pom</relativePath>
   </parent>
 

--- a/authn-support/pom.xml
+++ b/authn-support/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <relativePath>../parent-pom</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <relativePath>../parent-pom</relativePath>
   </parent>
 

--- a/dependency-bom/pom.xml
+++ b/dependency-bom/pom.xml
@@ -5,7 +5,7 @@
   <groupId>se.litsec.sweid.idp</groupId>
   <artifactId>shibboleth-base-dependency-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.1</version>
+  <version>1.1.1</version>
 
   <name>Swedish eID :: Dependency BOM :: Shibboleth IdP base dependencies</name>
   <description>BOM (Bill of Materials) for dependencies for users of the base packaging of Shibboleth IdP 3.X for the Swedish eID Framework</description>
@@ -38,8 +38,8 @@
 
   <properties>
     <opensaml.version>3.3.0</opensaml.version>
-    <opensaml-ext.version>0.9.1</opensaml-ext.version>
-    <opensaml.swedish-eid.version>0.9.1</opensaml.swedish-eid.version>
+    <opensaml-ext.version>0.9.2</opensaml-ext.version>
+    <opensaml.swedish-eid.version>0.9.2</opensaml.swedish-eid.version>
 
     <shibboleth.version>3.3.1</shibboleth.version>
     <shibboleth.java-support.version>7.3.0</shibboleth.java-support.version>

--- a/idp/pom.xml
+++ b/idp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <relativePath>../parent-pom</relativePath>
   </parent>
 

--- a/metadata-support/pom.xml
+++ b/metadata-support/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <relativePath>../parent-pom</relativePath>
   </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -5,7 +5,7 @@
   <groupId>se.litsec.sweid.idp</groupId>
   <artifactId>shibboleth-base-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.1</version>
+  <version>1.1.1</version>
 
   <name>Swedish eID :: Parent POM for Swedish eID :: Shibboleth IdP base</name>
   <description>Parent POM for base packaging of Shibboleth IdP 3.X for the Swedish eID Framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>se.litsec.sweid.idp</groupId>
   <artifactId>builder-pom</artifactId>
   <packaging>pom</packaging>
-  <version>1.1</version>
+  <version>1.1.1</version>
 
   <name>Swedish eID :: Builder POM for Swedish eID :: Shibboleth IdP base</name>
   <description>Builder POM for base packaging of Shibboleth IdP 3.X for the Swedish eID Framework</description>

--- a/shibboleth-extensions/pom.xml
+++ b/shibboleth-extensions/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <relativePath>../parent-pom</relativePath>
   </parent>
 


### PR DESCRIPTION
END-144 New release of Shibboleth base so that we solve bug corrected in opensaml-ext concerning bad metadata.