### PR TITLE
Added interceptor for preventing SSO

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,6 +4,7 @@
 
   <artifactId>shibboleth-base-bom</artifactId>
   <packaging>pom</packaging>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
@@ -46,7 +47,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>shibboleth-sweid-extensions</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
         <type>jar</type>
         <scope>provided</scope>
       </dependency>

--- a/idp/pom.xml
+++ b/idp/pom.xml
@@ -4,6 +4,7 @@
 
   <artifactId>shibboleth-base</artifactId>
   <packaging>pom</packaging>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
@@ -45,7 +46,7 @@
   </organization>  
 
   <properties>
-    <shibboleth-base-bom.version>1.4.1</shibboleth-base-bom.version>
+    <shibboleth-base-bom.version>1.4.2-SNAPSHOT</shibboleth-base-bom.version>
   </properties>
 
   <dependencyManagement>
@@ -218,7 +219,13 @@
                   </fileset>
                   <mapper type="glob" from="*" to="*.dist" />
                 </copy>
-                <!-- TODO: add flows and views later on -->
+                <copy todir="${project.build.directory}/shibboleth-identity-provider-${shibboleth.version}/dist/flows" overwrite="true" force="true">
+                  <fileset dir="${basedir}/src/main/resources/flows" includes="**/*">
+                    <type type="file" />
+                  </fileset>
+                  <mapper type="glob" from="*" to="*.dist" />
+                </copy>
+                <!-- TODO: add views later on -->
               </target>
             </configuration>
             <goals>

--- a/idp/src/main/resources/conf/intercept/profile-intercept.xml
+++ b/idp/src/main/resources/conf/intercept/profile-intercept.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+                           
+       default-init-method="initialize"
+       default-destroy-method="destroy">
+
+    <!--
+    Intercept flows are used at various injection points to modify processing. This is the master list
+    of flows available that provide interesting features to deployers, but flows are actually enabled by
+    specifying them in various profile configuration beans via relying-party.xml 
+    
+    This list of flows is merged with a built-in set defined in a system configuration file, and may be
+    empty, but should not be removed. You must add your own custom flows to this list if you create any.
+    -->
+    
+    <bean id="shibboleth.AvailableInterceptFlows" parent="shibboleth.DefaultInterceptFlows" lazy-init="true">
+        <property name="sourceList">
+            <list merge="true">
+                <!-- For preventing SSO (used for signature services) -->
+                <bean id="intercept/prevent-sso" parent="shibboleth.InterceptFlow" />
+                                
+                <bean id="intercept/context-check" parent="shibboleth.InterceptFlow" />                
+                <bean id="intercept/expiring-password" parent="shibboleth.InterceptFlow" />        
+                <bean id="intercept/terms-of-use" parent="shibboleth.consent.TermsOfUseFlow" />        
+                <bean id="intercept/attribute-release" parent="shibboleth.consent.AttributeReleaseFlow" />
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/idp/src/main/resources/conf/relying-party.xml
+++ b/idp/src/main/resources/conf/relying-party.xml
@@ -66,6 +66,23 @@
 
     <util:list id="shibboleth.RelyingPartyOverrides">
     
+      <!--
+        For signature services we never allow SSO. So, trigger the prevent-sso interceptor flow. 
+       -->
+      <bean parent="RelyingPartyByTag">
+        <constructor-arg name="candidates">
+          <list>
+            <bean parent="TagCandidate" c:name="http://macedir.org/entity-category" p:values="http://id.elegnamnden.se/st/1.0/sigservice"/>
+          </list>
+        </constructor-arg>
+        <property name="profileConfigurations">
+          <list>
+            <bean parent="sweid.SAML2.SSO"
+              p:inboundInterceptorFlows="#{{ 'security-policy/saml2-sso', 'prevent-sso' }}" />          
+          </list>
+        </property>
+      </bean>    
+    
         <!--
         Override example that identifies a single RP by name and configures it
         for SAML 2 SSO without encryption. This is a common "vendor" scenario.

--- a/idp/src/main/resources/flows/intercept/prevent-sso/prevent-sso-beans.xml
+++ b/idp/src/main/resources/flows/intercept/prevent-sso/prevent-sso-beans.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:util="http://www.springframework.org/schema/util"       
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+
+       default-init-method="initialize"
+       default-destroy-method="destroy">
+       
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"
+        p:placeholderPrefix="%{" p:placeholderSuffix="}" />
+
+    <bean class="net.shibboleth.ext.spring.config.IdentifiableBeanPostProcessor" />
+    <bean class="net.shibboleth.idp.profile.impl.ProfileActionBeanPostProcessor" />
+    
+    <bean id="PreventSsoAction" class="se.litsec.shibboleth.idp.profile.interceptor.SsoPreventionInterceptorAction" />
+    
+</beans>

--- a/idp/src/main/resources/flows/intercept/prevent-sso/prevent-sso-flow.xml
+++ b/idp/src/main/resources/flows/intercept/prevent-sso/prevent-sso-flow.xml
@@ -1,0 +1,18 @@
+ <flow xmlns="http://www.springframework.org/schema/webflow"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/webflow http://www.springframework.org/schema/webflow/spring-webflow.xsd"
+       parent="intercept.abstract">
+
+    <input name="calledAsSubflow" type="boolean" required="true" />
+    
+    <action-state id="PreventSso">
+      <evaluate expression="PreventSsoAction" />
+      <evaluate expression="'proceed'" />        
+      <transition on="proceed" to="proceed" />
+    </action-state>
+
+    <end-state id="proceed" />
+
+    <bean-import resource="prevent-sso-beans.xml" />
+
+</flow>

--- a/shibboleth-extensions/pom.xml
+++ b/shibboleth-extensions/pom.xml
@@ -3,7 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>shibboleth-sweid-extensions</artifactId>
-  <packaging>jar</packaging>  
+  <packaging>jar</packaging>
+  <version>1.4.2-SNAPSHOT</version>
 
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>

--- a/shibboleth-extensions/src/main/java/se/litsec/shibboleth/idp/profile/interceptor/SsoPreventionInterceptorAction.java
+++ b/shibboleth-extensions/src/main/java/se/litsec/shibboleth/idp/profile/interceptor/SsoPreventionInterceptorAction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2018 Litsec AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.litsec.shibboleth.idp.profile.interceptor;
+
+import org.opensaml.messaging.context.navigate.MessageLookup;
+import org.opensaml.profile.context.ProfileRequestContext;
+import org.opensaml.profile.context.navigate.InboundMessageContextLookup;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+
+import net.shibboleth.idp.profile.context.ProfileInterceptorContext;
+import net.shibboleth.idp.profile.interceptor.AbstractProfileInterceptorAction;
+
+/**
+ * Interceptor action that prevents SSO from happening. This should be used for signature services. 
+ * 
+ * @author Martin Lindström (martin.lindstrom@litsec.se)
+ */
+@SuppressWarnings("rawtypes")
+public class SsoPreventionInterceptorAction extends AbstractProfileInterceptorAction {
+
+  /** Class logger. */
+  private final Logger log = LoggerFactory.getLogger(SsoPreventionInterceptorAction.class);
+  
+  /** Strategy used to locate the {@link AuthnRequest} to operate on. */
+  protected static Function<ProfileRequestContext, AuthnRequest> requestLookupStrategy = Functions.compose(
+    new MessageLookup<>(AuthnRequest.class), new InboundMessageContextLookup());
+
+  /** {@inheritDoc} */
+  @Override
+  protected void doExecute(final ProfileRequestContext profileRequestContext, final ProfileInterceptorContext interceptorContext) {
+    
+    AuthnRequest authnRequest = requestLookupStrategy.apply(profileRequestContext);
+    if (authnRequest != null) {
+      if (authnRequest.isForceAuthn() == null || authnRequest.isForceAuthn() == Boolean.FALSE) {
+        log.info("{} AuthnRequest '{}' from '{}' has does not require forced authentication - enforcing it", 
+          this.getLogPrefix(), authnRequest.getID(), authnRequest.getIssuer() != null ? authnRequest.getIssuer().getValue() : "-");
+        authnRequest.setForceAuthn(true);
+      }
+    }
+  }
+
+}

--- a/shibboleth-extensions/src/main/java/se/litsec/shibboleth/idp/profile/interceptor/package-info.java
+++ b/shibboleth-extensions/src/main/java/se/litsec/shibboleth/idp/profile/interceptor/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Action beans for custom interceptors. 
+ */
+package se.litsec.shibboleth.idp.profile.interceptor;


### PR DESCRIPTION
A signature service MUST never use SSO. Therefore, we added an
interceptor flow that prevents SSO for a signature service even if it
sets the ForceAuthn-flag of the AuthnRequest to false.