### PR TITLE
Fixed dependencies to Jackson

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ See the [Shibboleth 3.4 Release notes](https://wiki.shibboleth.net/confluence/di
 
 ------
 
-Copyright &copy; 2017-2018, [Litsec AB](http://www.litsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2017-2019, [Litsec AB](http://www.litsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/dependency-bom/pom.xml
+++ b/dependency-bom/pom.xml
@@ -5,7 +5,7 @@
   <groupId>se.litsec.sweid.idp</groupId>
   <artifactId>shibboleth-base-dependency-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.6.0</version>
+  <version>1.6.1-SNAPSHOT</version>
 
   <name>Swedish eID :: Dependency BOM :: Shibboleth IdP base dependencies</name>
   <description>BOM (Bill of Materials) for dependencies for users of the base packaging of Shibboleth IdP 3.X for the Swedish eID Framework</description>
@@ -41,8 +41,8 @@
 
   <properties>
     <opensaml.version>3.4.0</opensaml.version>
-    <opensaml-ext.version>1.2.2</opensaml-ext.version>
-    <opensaml.swedish-eid.version>1.2.1</opensaml.swedish-eid.version>
+    <opensaml-ext.version>1.2.3</opensaml-ext.version>
+    <opensaml.swedish-eid.version>1.2.2</opensaml.swedish-eid.version>
 
     <shibboleth.version>3.4.1</shibboleth.version>
     <shibboleth.java-support.version>7.4.1</shibboleth.java-support.version>
@@ -56,7 +56,7 @@
     <spring.webflow.version>2.4.8.RELEASE</spring.webflow.version>
     <spring.mobile.version>1.1.5.RELEASE</spring.mobile.version>
     
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
 
     <slf4j.version>1.7.25</slf4j.version>
     <junit.version>4.12</junit.version>

--- a/shibboleth-base/idp/pom.xml
+++ b/shibboleth-base/idp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <name>Swedish eID :: Base packaging of Shibboleth IdP 3.X</name>

--- a/shibboleth-base/pom.xml
+++ b/shibboleth-base/pom.xml
@@ -5,7 +5,7 @@
   <groupId>se.litsec.sweid.idp</groupId>
   <artifactId>shibboleth-base-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.6.0</version>
+  <version>1.6.1-SNAPSHOT</version>
 
   <name>Swedish eID :: Parent POM for Swedish eID :: Shibboleth IdP base</name>
   <description>Parent POM for base packaging of Shibboleth IdP 3.X for the Swedish eID Framework</description>
@@ -48,8 +48,8 @@
         
     <!-- Needed only for the Javadoc plugin (we don't get the versions from the BOM). -->
     <opensaml.version>3.4.0</opensaml.version>
-    <opensaml-ext.version>1.2.2</opensaml-ext.version>
-    <opensaml.swedish-eid.version>1.2.1</opensaml.swedish-eid.version>
+    <opensaml-ext.version>1.2.3</opensaml-ext.version>
+    <opensaml.swedish-eid.version>1.2.2</opensaml.swedish-eid.version>
     
   </properties>
 
@@ -241,7 +241,7 @@
                 <link>https://litsec.github.io/opensaml-ext/javadoc/ext/org/opensaml/opensaml-storage-impl/${opensaml.version}/</link>
                 <link>https://litsec.github.io/opensaml-ext/javadoc/ext/org/opensaml/opensaml-xmlsec-api/${opensaml.version}/</link>
                 <link>https://litsec.github.io/opensaml-ext/javadoc/ext/org/opensaml/opensaml-xmlsec-impl/${opensaml.version}/</link>
-                <link>https://litsec.github.io/opensaml-ext/javadoc/ext/net/shibboleth/utilities/java-support/7.4.0/</link>                
+                <link>https://litsec.github.io/opensaml-ext/javadoc/ext/net/shibboleth/utilities/java-support/7.4.1/</link>                
                 <link>https://litsec.github.io/opensaml-ext/javadoc/ext/net/shibboleth/ext/spring-extensions/5.4.0/</link>
                 <link>https://litsec.github.io/opensaml-ext/javadoc/opensaml3/${opensaml-ext.version}/</link>
                 <link>https://litsec.github.io/swedish-eid-opensaml/javadoc/${opensaml.swedish-eid.version}/</link>

--- a/shibboleth-base/shibboleth-extensions/pom.xml
+++ b/shibboleth-base/shibboleth-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>se.litsec.sweid.idp</groupId>
     <artifactId>shibboleth-base-parent</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <name>Swedish eID :: Shibboleth IdP Extension Library</name>


### PR DESCRIPTION
2.9.7 had reported vulnerabilities. Upgraded to 2.9.8.